### PR TITLE
only show dashboard widget to selected user role and above

### DIFF
--- a/RecentRevisions.php
+++ b/RecentRevisions.php
@@ -88,7 +88,7 @@ function RecentRevisions() {
 					$post_meta .= ' (<a href="revision.php?action=diff&post_type=page&right=' . $post->ID . '&left=' . $prevId . '">' . __('diff', 'recent-revisions') . '</a>)';
 				}
 			}
-				
+
 			//print it out
 			?>
 <li class='post-meta'><?php echo $post_meta; ?>
@@ -108,11 +108,36 @@ function RecentRevisions() {
 
 
 function RecentRevisions_Init() {
-	wp_add_dashboard_widget( 'RecentRevisions', __( 'Recent Revisions', 'recent-revisions' ), 'RecentRevisions', 'RecentRevisions_Setup');
+	$options = RecentRevisions_Options();
+
+	switch ($options['permissions']) {
+		case 'subscriber':
+			$capability = 'read';
+			break;
+		case 'contributor':
+			$capability = 'edit_posts';
+			break;
+		case 'author':
+			$capability = 'edit_published_posts';
+			break;
+		case 'editor':
+			$capability = 'edit_others_posts';
+			break;
+		case 'administrator':
+			$capability = 'manage_options';
+			break;
+		default:
+			$capability = 'edit_posts';
+			break;
+	}
+
+	if ( current_user_can( $capability ) ) {
+		wp_add_dashboard_widget( 'RecentRevisions', __( 'Recent Revisions', 'recent-revisions' ), 'RecentRevisions', 'RecentRevisions_Setup');
+	}
 }
 
 function RecentRevisions_Options() {
-	$defaults = array( 'items' => 25, 'showdatetime' => 1, 'showauthor' => 1, 'tz_gmt' => 0, 'showdiff' => 0);
+	$defaults = array( 'items' => 25, 'permissions' => 'contributor', 'showdatetime' => 1, 'showauthor' => 1, 'tz_gmt' => 0, 'showdiff' => 0);
 	if ( ( !$options = get_option( 'RecentRevisions' ) ) || !is_array($options) )
 	$options = array();
 	return array_merge( $defaults, $options );
@@ -126,6 +151,7 @@ function RecentRevisions_Setup() {
 	if ( 'post' == strtolower($_SERVER['REQUEST_METHOD']) && isset( $_POST['widget_id'] ) && 'RecentRevisions' == $_POST['widget_id'] ) {
 		foreach ( array( 'items', 'showdatetime', 'showauthor', 'tz_gmt', 'showdiff' ) as $key )
 		$options[$key] = (int) @$_POST[$key];
+		$options['permissions'] = $_POST['permissions'];
 		update_option( 'RecentRevisions', $options );
 	}
 
@@ -138,6 +164,16 @@ function RecentRevisions_Setup() {
 		echo "<option value='$i'" . ( $options['items'] == $i ? " selected='selected'" : '' ) . ">$i</option>";
 		?>
 	</select> </label>
+</p>
+
+<p>
+	<label for="permissions"><?php _e('Minimum role to view recent revisions', 'recent-revisions' ); ?></label>
+	<select name="permissions" id="permissions">
+		<?php
+		$roles = array('subscriber', 'contributor', 'author', 'editor', 'administrator');
+		foreach ( $roles as $role )
+			echo "<option value='$role'" . ( $options['permissions'] == $role ? " selected='selected'" : '' ) . ">".ucfirst($role)."</option>";
+		?></select>
 </p>
 
 <p>


### PR DESCRIPTION
New updates - user role checking in place

![Admin interface](https://cloud.githubusercontent.com/assets/5274747/6716607/dfebaf48-cda6-11e4-9a95-fb1e654ce92a.png)

Notes:
Seeing as we can’t check for ‘greater than’ a particular user role, we use the standardized capabilities built into WP http://codex.wordpress.org/Roles_and_Capabilities

Standardized list of roles are used - 'subscriber', 'contributor', 'author', 'editor', 'administrator’ as we have the known capabilities for these

The variable had to be saved separately of the array (as all the array values are encoded into integers) $options['permissions'] = $_POST['permissions'];

TESTS:
No options saved (default is contributor)
Subscriber role - cannot see plugin
Contributor role - can see plugin
Author role - can see plugin
Editor role - can see plugin
Administrator role - can see plugin
PASS

Option saved - Subscriber
Subscriber role - can see plugin
Contributor role - can see plugin
Author role - can see plugin
Editor role - can see plugin
Administrator role - can see plugin
PASS

Option saved - Contributor
Subscriber role - cannot see plugin
Contributor role - can see plugin
Author role - can see plugin
Editor role - can see plugin
Administrator role - can see plugin
PASS

Option saved - Author
Subscriber role - cannot see plugin
Contributor role - cannot see plugin
Author role - can see plugin
Editor role - can see plugin
Administrator role - can see plugin
PASS

Option saved - Editor
Subscriber role - cannot see plugin
Contributor role - cannot see plugin
Author role - cannot see plugin
Editor role - can see plugin
Administrator role - can see plugin
PASS

Option saved - Administrator
Subscriber role - cannot see plugin
Contributor role - cannot see plugin
Author role - cannot see plugin
Editor role - cannot see plugin
Administrator role - can see plugin
PASS
